### PR TITLE
Add hint on browser back button and turbolinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,22 @@ into `application.scss` or
 
 into `application.css`.
 
+ 
 You may use [this](https://github.com/bodrovis/jquery-slick-rails-demo) simple Rails app as an example
 (it also shows how to use the plugin with Turbolinks).
 
+## Gotcha
+
+Slick and browser back button with turbolinks
+
+you may want to make use of
+
+    $(document).on('turbolinks:load', $('#my-slider').slick({}) 
+    $(document).on('turbolinks:before-cache', $('#my-slider').slick('unslick')) 
+
+to make slick work in case it broke...
+
+as mentioned [on stackoverflow](http://stackoverflow.com/questions/39627881/jquery-plugin-initialization-on-browser-back-button-for-turbolinks-rails-5)
 ## Testing
 
 Run


### PR DESCRIPTION
I ran into some hazzle with the browser back button while making use of a autoplayed slick slider.
only solution was to unslick the slicks on turbolinks:before-cache.

so i thought this would be worth a note in README.