### PR TITLE
fix(outer edge whitespace): fix the whitespace after the last slide:

### DIFF
--- a/app/assets/javascripts/jquery.slick.js
+++ b/app/assets/javascripts/jquery.slick.js
@@ -66,6 +66,7 @@
         initialSlide: 0,
         lazyLoad: 'ondemand',
         mobileFirst: false,
+        outerEdgeLimit: false,
         pauseOnHover: true,
         pauseOnFocus: true,
         pauseOnDotsHover: false,
@@ -1174,6 +1175,14 @@
         }
 
         targetLeft += (_.$list.width() - targetSlide.outerWidth()) / 2;
+        } else if (_.options.outerEdgeLimit) {
+          var lastSlide,
+              lastLeft,
+              outerEdgeLimit;
+          lastSlide = _.$slides.last();
+          lastLeft = lastSlide[0] ? lastSlide[0].offsetLeft * -1 : 0;
+          outerEdgeLimit = lastLeft - lastSlide.width() + this.$slider.width();
+          targetLeft = Math.min(Math.max(targetLeft, outerEdgeLimit), 0);
       }
     }
 


### PR DESCRIPTION
when infinite = false:

When infinite is set to false the last slide would come all the way to the left, thus leaving a whitespace the size of the slider container.

This use [this pull request](https://github.com/kenwheeler/slick/pull/2635) on source library to correct this behavior.