### PR TITLE
readme fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ The idea is that we are [opting the page out of caching](https://github.com/turb
 Another solution was to employ the `unslick` method to prepare your document before Turbolinks caches it:
 
 ```javascript
-jQuery(document).on('turbolinks:before-cache', $('.scroller').slick('unslick'))
+jQuery(document).on('turbolinks:before-cache', function() { $('.scroller').slick('unslick') })
 ```
     
 However, this does not seem to work anymore - maybe because [Slick has lots of opened issues related to unslick](https://github.com/kenwheeler/slick/search?q=unslick&type=Issues&utf8=%E2%9C%93).


### PR DESCRIPTION
Event handler for turbolinks:before-cache should be wrapped around with "function", because otherwise it will be executed at them moment of creating event handler.  And btw this method worked for me.
